### PR TITLE
Makes the bot more resilient to slow connections/network failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,6 +206,17 @@ setupCanvas();
 let baseCtx = baseCanvas.getContext("2d");
 let drawCtx = drawCanvas.getContext("2d");
 
+/**
+ * Gets the data for a specific chunk.
+ *
+ * Automatically retries up to 5 times in case of failure before throwing an error,
+ * e.g. if the POAP.art servers are being slow, causing a Cloudflare CDN error.
+ *
+ * @param {number} row - Chunk row number.
+ * @param {number} col - Chunk column number.
+ * @returns {Promise<ArrayBuffer>} The chunk data, where each byte is a UInt8
+ * representing the colorId in the palette array. (e.g. 1 will be #F3F3F4).
+ */
 async function getChunk(row, col)
 {
     if (canvasId === "")
@@ -214,8 +225,34 @@ async function getChunk(row, col)
     // commenting out since official website no longer uses this
     // and keeping it may invalid caching
     // url.searchParams.set("since", secondsSinceEpoch().toString(16));
-    const response = await fetch(url);
-    return await response.arrayBuffer();
+    const maxTries = 5; // try 5 times before failing
+    let tries = 0;
+    while (true) {
+      try {
+        const response = await fetch(url);
+        if (response.ok) {
+          return await response.arrayBuffer();
+        } else {
+          throw new Error(
+            `Fetching ${url} failed with code ${response.status}, `
+            + `and text ${await response.text()}`
+          );
+        }
+      } catch (error) {
+        tries++;
+        if (tries < maxTries) {
+          console.warn(
+            `Failed ${tries} times at loading chunk ${url} with error ${error}.\n`
+            + `Retrying after a delay of ${tries} seconds.`
+          );
+          await delay(1000 * tries);
+        } else {
+          throw new Error(
+            `Failed ${tries} times at loading chunk ${url}. Latest error was ${error}.`
+          );
+        }
+      }
+    }
 }
 
 let palette = ["FFFFFF","F3F3F4","E7E7EA","DBDBDF","CFCFD4","C3C3C9","B7B7BF","ABABB4","9F9FA9","93939E","878794","7B7B89","6F6F7E","636373","575769","4B4B5E","F9F9F9","E8E8E8","D8D8D8","C7C7C7","B7B7B7","A6A6A6","959595","858585","747474","646464","535353","424242","323232","212121","111111","000000","FFF0DC","FEEAD5","FDE5CE","FCDFC7","FADABF","F9D4B8","F8CFB1","F7C9AA","F1BB9E","EAAE93","E4A088","DE937C","D78571","D17765","CA6A5A","C45C4E","EADCDA","DEC9C5","D1B6B1","C5A39C","B88F88","AC7C73","9F695F","93564A","885045","7C4940","71433B","663D36","5A3630","4F302B","432926","382321","FFD4D4","FDB6B6","FC9797","FA7979","F95B5B","F73D3D","F61E1E","F40000","E00000","CB0000","B70000","A30101","8E0101","7A0101","650101","510101","FFE1CC","FFD0AF","FFBE92","FFAD75","FF9B57","FF8A3A","FF781D","FF6700","EF6202","DF5D04","CF5805","BF5307","AF4E09","9F490B","8F440C","7F3F0E","FFF8E1","FFF3C7","FFEEAD","FFE993","FFE57A","FFE060","FFDB46","FFD62C","EEC72A","DEB928","CDAA26","BD9C24","AC8D21","9B7E1F","8B701D","7A611B","FFFACF","FFF9BE","FFF9AE","FFF89D","FEF78C","FEF67B","FEF66B","FFF200","EDE002","DCCE04","CABC06","B9AA08","A79709","95850B","84730D","72610F","F1FFCF","E7FFB1","DCFF94","D2FF76","C7FF59","BDFF3B","B2FF1E","A8FF00","9BEA01","8ED401","81BF02","74AA02","669403","597F03","4C6904","3F5404","C5FFC5","AEFAAE","96F596","7FF07F","68EC68","51E751","39E239","22DD22","20CB20","1DBA1D","1BA81B","189618","168416","147314","116111","0F4F0F","CAFFF6","ADFFF2","90FFEE","73FFEA","57FFE6","3AFFE2","1DFFDE","00FFDA","01E7C5","01CFB1","02B79C","039F88","038773","046F5E","04574A","053F35","E1FEFF","CBF9FF","B5F5FF","9FF0FF","8AEBFF","74E6FF","5EE2FF","48DDFF","40CCEB","38BCD7","2FABC3","279BB0","1F8A9C","167988","0E6974","065860","D4DEFF","B6C2FF","97A6FF","798AFF","5B6DFF","3D51FF","1E35FF","0019FF","0016EB","0113D7","0110C3","010EB0","010B9C","020888","020574","020260","F0E3FF","E3C3FF","D6A2FF","C982FF","BC61FF","AF41FF","A220FF","9500FF","8700E9","7900D3","6B00BD","5E00A7","500091","42007B","340065","26004F","FFE3FC","FFD0F8","FFBDF4","FFAAF0","FF98ED","FF85E9","FF72E5","FF5FE1","F056D3","E04DC6","D144B8","C23BAB","B2329D","A3298F","932082","841774","F9E1ED","FAC8DE","FBAFCF","FC96C0","FC7CB2","FD63A3","FE4A94","FF3185","EB2D7B","D72A71","C32667","B0225E","9C1E54","881A4A","741740","601336"]

--- a/index.js
+++ b/index.js
@@ -304,7 +304,8 @@ async function paintPixel(x, y, color)
         body: JSON.stringify(data),
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + bearer
+            'Authorization': 'Bearer ' + bearer,
+            'X-POAP-Art-Bot': 'RamiRond Bot', // in case POAP.art team needs to block us
         },
         signal, // fetch will timeout after xxx seconds
     };

--- a/index.js
+++ b/index.js
@@ -182,7 +182,10 @@ async function getChunk(row, col)
 {
     if (canvasId === "")
         return;
-    let url = baseUrl + canvasId + "/chunk/" + row + ":" + col + "?since=" + secondsSinceEpoch().toString(16);
+    const url = new URL(`${baseUrl}${canvasId}/chunk/${row}:${col}`);
+    // commenting out since official website no longer uses this
+    // and keeping it may invalid caching
+    // url.searchParams.set("since", secondsSinceEpoch().toString(16));
     const response = await fetch(url);
     return await response.arrayBuffer();
 }


### PR DESCRIPTION
Two weekends ago (August 7th-8th), the POAP.art sandbox was lagging quite a bit, with lots of requests timing out.

I made some changes to make the bot more resilient to cases where requests were failing.

Please see each individual commit message for more details on changes made, but as a summary:

- Cancel `paint` calls if they don't finish within 5 seconds (this is what the official POAP.art website does)
- Reconnect the Websocket URL if connection ever fails.
- Removes the `?since=time` HTTP parameter when loading chunks, since the POAP.art website doesn't use it.
  (plus this means that POAP.art's CDN can cache the calls)
- Tidy up Websocket event handling, so that we can ignore `"online"` events instead of `console.log`-ing them.
- Retry loading chunks up to 5 times, in case of error. Otherwise the POAP.art bot was only loading half the canvas.
- Finally, I added an `X-POAP-Art-Bot` HTTP header to all the `paint` calls. The Poap.art haven't asked for this, but I thought it would be polite to add it it in anyway, just in case they want to use it for stats, or if they ever need to block us in an emergency.

I know this is a big pull request, so please let me know if you want me to make separate pull requests for each topic!